### PR TITLE
Re-enable tests for GetComputerNameExW function

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,20 +1,20 @@
 {
-    "configurations": [
-        {
-            "name": "Win32",
-            "includePath": [
-                "${workspaceFolder}/**"
-            ],
-            "defines": [
-                "_DEBUG",
-                "UNICODE",
-                "_UNICODE"
-            ],
-            "windowsSdkVersion": "10.0.17134.0",
-            "cStandard": "c11",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "msvc-x64"
-        }
-    ],
-    "version": 4
+  "configurations": [
+    {
+      "name": "Win32",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "defines": [
+        "_DEBUG",
+        "UNICODE",
+        "_UNICODE"
+      ],
+      "windowsSdkVersion": "10.0.17134.0",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "msvc-x64"
+    }
+  ],
+  "version": 4
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,14 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"ms-vscode.csharp",
-		"tintoy.msbuild-project-tools",
-		"ms-vscode.cpptools"
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-
-	]
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "codezombiech.gitignore",
+    "ms-dotnettools.csharp",
+    "tintoy.msbuild-project-tools",
+    "ms-vscode.cpptools",
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,28 @@
 ﻿{
-   // Use IntelliSense to find out which attributes exist for C# debugging
-   // Use hover for the description of the existing attributes
-   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-   "version": "0.2.0",
-   "configurations": [
-        {
-            "name": ".NET Core Launch (console)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.1/THNETII.WinApiNative.Test.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/test/THNETII.WinApiNative.Test",
-            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
-            "console": "internalConsole",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart"
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
-        }
-    ,]
+  // Use IntelliSense to find out which attributes exist for C# debugging
+  // Use hover for the description of the existing attributes
+  // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (console)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/bin/Debug/netcoreapp2.1/THNETII.WinApiNative.Test.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/test/THNETII.WinApiNative.Test",
+      // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+      "console": "internalConsole",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    },
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,23 +1,23 @@
 ﻿{
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-          "label": "test",
-          "command": "dotnet",
-          "type": "process",
-          "args": [
-              "test"
-          ],
-          "problemMatcher": "$msCompile"
-      }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "test",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "test"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
 }

--- a/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
+++ b/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -92,7 +92,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameExA(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder.ToString(0, length);
+            var path = pathBuilder?.ToString(0, length);
             Assert.NotNull(path);
         }
 
@@ -104,7 +104,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameExW(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder.ToString(0, length);
+            var path = pathBuilder?.ToString(0, length);
             Assert.NotNull(path);
         }
 
@@ -116,7 +116,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameEx(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder.ToString(0, length);
+            var path = pathBuilder?.ToString(0, length);
             Assert.NotNull(path);
         }
 

--- a/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
+++ b/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
@@ -92,11 +92,11 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameExA(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder?.ToString(0, length);
+            var path = pathBuilder.ToString(0, length);
             Assert.NotNull(path);
         }
 
-        [TheoryWindowsOS]
+        [TheoryWindowsOS(Skip = "Disabled and blocked on https://github.com/thnetii/windows-api/pull/105")]
         [MemberData(nameof(Get_COMPUTER_NAME_FORMAT))]
         public static void Can_call_unicode_marshaling_extern_function(COMPUTER_NAME_FORMAT nameType)
         {
@@ -104,11 +104,11 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameExW(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder?.ToString(0, length);
+            var path = pathBuilder.ToString(0, length);
             Assert.NotNull(path);
         }
 
-        [TheoryWindowsOS]
+        [TheoryWindowsOS(Skip = "Disabled and blocked on https://github.com/thnetii/windows-api/pull/105")]
         [MemberData(nameof(Get_COMPUTER_NAME_FORMAT))]
         public static void Can_call_auto_marshaling_extern_function(COMPUTER_NAME_FORMAT nameType)
         {
@@ -116,7 +116,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             bool successful = GetComputerNameEx(nameType, pathBuilder, out int length);
             if (!successful)
                 throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
-            var path = pathBuilder?.ToString(0, length);
+            var path = pathBuilder.ToString(0, length);
             Assert.NotNull(path);
         }
 

--- a/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
+++ b/test/THNETII.WinApi.Native.Test/SysInfoApi.Test/GetComputerNameEx.cs
@@ -96,7 +96,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             Assert.NotNull(path);
         }
 
-        [TheoryWindowsOS(Skip = "Disabled and blocked on https://github.com/thnetii/windows-api/pull/105")]
+        [TheoryWindowsOS]
         [MemberData(nameof(Get_COMPUTER_NAME_FORMAT))]
         public static void Can_call_unicode_marshaling_extern_function(COMPUTER_NAME_FORMAT nameType)
         {
@@ -108,7 +108,7 @@ namespace THNETII.WinApi.Native.SysInfoApi.Test
             Assert.NotNull(path);
         }
 
-        [TheoryWindowsOS(Skip = "Disabled and blocked on https://github.com/thnetii/windows-api/pull/105")]
+        [TheoryWindowsOS]
         [MemberData(nameof(Get_COMPUTER_NAME_FORMAT))]
         public static void Can_call_auto_marshaling_extern_function(COMPUTER_NAME_FORMAT nameType)
         {


### PR DESCRIPTION
#104 disables the unit tests for the `GetComputerNameExW` function. This PR tracks the investigation into the reason for the tests failing and ultimately re-enables these tests.