### PR TITLE
Fix Documentation comment warnings for native APIs

### DIFF
--- a/src-native-c/THNETII.WinApi.Sample.Native/main.c
+++ b/src-native-c/THNETII.WinApi.Sample.Native/main.c
@@ -6,7 +6,7 @@ int main(int argc, char* argv[])
     const int size = sizeof(instance);
     const int value = FORMAT_MESSAGE_ALLOCATE_BUFFER;
 
-    const void* ptr = ConvertDefaultLocale;
+    const void* ptr = HeapFree;
 
     return EXIT_SUCCESS;
 }

--- a/src-native-c/THNETII.WinApi.Sample.Native/main.c
+++ b/src-native-c/THNETII.WinApi.Sample.Native/main.c
@@ -6,7 +6,7 @@ int main(int argc, char* argv[])
     const int size = sizeof(instance);
     const int value = FORMAT_MESSAGE_ALLOCATE_BUFFER;
 
-    const void* ptr = FormatMessage;
+    const void* ptr = ConvertDefaultLocale;
 
     return EXIT_SUCCESS;
 }

--- a/src-native/THNETII.WinApi.Constants.WinBase/GlobalSuppressions.cs
+++ b/src-native/THNETII.WinApi.Constants.WinBase/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿
+
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
@@ -6,5 +6,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Naming", "CA1707: Identifiers should not contain underscores")]
-[assembly: SuppressMessage("Design", "CA1051: Do not declare visible instance fields")]
+[assembly: SuppressMessage("Design",
+    "CA1051: Do not declare visible instance fields")]
+[assembly: SuppressMessage("Documentation",
+    "CA1200: Avoid using cref tags with a prefix")]
+[assembly: SuppressMessage("Naming",
+    "CA1707: Identifiers should not contain underscores")]

--- a/src-native/THNETII.WinApi.Constants.WinBase/WinBaseConstants.cs
+++ b/src-native/THNETII.WinApi.Constants.WinBase/WinBaseConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace THNETII.WinApi.Native.WinBase
+namespace THNETII.WinApi.Native.WinBase
 {
     using static WinNT.WinNTConstants;
 
@@ -19,7 +19,7 @@
 
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\WinBase.h, line 2380
         /// <summary>
-        /// <see cref="FORMAT_MESSAGE_ALLOCATE_BUFFER"/> requires use of <see cref="HeapFree"/>
+        /// <see cref="FORMAT_MESSAGE_ALLOCATE_BUFFER"/> requires use of <see cref="M:THNETII.WinApi.Native.HeapApi.HeapApiFunctions.HeapFree(THNETII.WinApi.Native.HeapApi.HEAP_HANDLE,THNETII.WinApi.Native.HeapApi.HEAP_FLAGS,THNETII.WinApi.Native.HeapApi.HEAP_MEMORY)"/>
         /// </summary>
         public const int FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100;
 

--- a/src-native/THNETII.WinApi.Constants.WinNT/WinNTConstants.cs
+++ b/src-native/THNETII.WinApi.Constants.WinNT/WinNTConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Principal;
 
 namespace THNETII.WinApi.Native.WinNT
@@ -284,7 +284,7 @@ namespace THNETII.WinApi.Native.WinNT
         public const int LANG_BRETON = 0x7e;
         /// <summary>Use with <strong>SUBLANG_BOSNIAN_*</strong> Sublanguage IDs</summary>
         public const int LANG_BOSNIAN = 0x1a;
-        /// <summary>Use with the <see cref="ConvertDefaultLocale"/> function</summary>
+        /// <summary>Use with the <see cref="M:THNETII.WinApi.Native.WinNls.WinNlsFunctions.ConvertDefaultLocale(System.Int32)"/> function</summary>
         public const int LANG_BOSNIAN_NEUTRAL = 0x781a;
         public const int LANG_BULGARIAN = 0x02;
         public const int LANG_CATALAN = 0x03;
@@ -292,9 +292,9 @@ namespace THNETII.WinApi.Native.WinNT
         public const int LANG_CHEROKEE = 0x5c;
         /// <summary>Use with <strong>SUBLANG_CHINESE_*</strong> Sublanguage IDs</summary>
         public const int LANG_CHINESE = 0x04;
-        /// <summary>Use with the <see cref="ConvertDefaultLocale"/> function</summary>
+        /// <summary>Use with the <see cref="M:THNETII.WinApi.Native.WinNls.WinNlsFunctions.ConvertDefaultLocale(System.Int32)"/> function</summary>
         public const int LANG_CHINESE_SIMPLIFIED = 0x04;
-        /// <summary>Use with the <see cref="ConvertDefaultLocale"/> function</summary>
+        /// <summary>Use with the <see cref="M:THNETII.WinApi.Native.WinNls.WinNlsFunctions.ConvertDefaultLocale(System.Int32)"/> function</summary>
         public const int LANG_CHINESE_TRADITIONAL = 0x7c04;
         public const int LANG_CORSICAN = 0x83;
         public const int LANG_CROATIAN = 0x1a;
@@ -380,7 +380,7 @@ namespace THNETII.WinApi.Native.WinNT
         public const int LANG_SCOTTISH_GAELIC = 0x91;
         /// <summary>Use with the <strong>SUBLANG_SERBIAN_*</strong> Sublanguage IDs</summary>
         public const int LANG_SERBIAN = 0x1a;
-        /// <summary>Use with the <see cref="ConvertDefaultLocale"/> function</summary>
+        /// <summary>Use with the <see cref="M:THNETII.WinApi.Native.WinNls.WinNlsFunctions.ConvertDefaultLocale(System.Int32)"/> function</summary>
         public const int LANG_SERBIAN_NEUTRAL = 0x7c1a;
         public const int LANG_SINDHI = 0x59;
         public const int LANG_SINHALESE = 0x5b;

--- a/src-native/THNETII.WinApi.Headers.ErrHandlingApi/ErrHandlingApiFunctions.cs
+++ b/src-native/THNETII.WinApi.Headers.ErrHandlingApi/ErrHandlingApiFunctions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using THNETII.InteropServices.Memory;
 using THNETII.WinApi.Native.WinBase;
 
 #if NETSTANDARD1_6
@@ -165,26 +166,96 @@ namespace THNETII.WinApi.Native.ErrHandlingApi
         /// <item><term><strong>Minimum supported server:</strong></term><description>Windows Server 2003 [desktop apps | UWP apps]</description></item>
         /// </list>
         /// </para>
-        /// <para>Microsoft Docs page: <a href="https://msdn.microsoft.com/en-us/library/ms679336.aspx">FatalAppExit function</a></para>
+        /// <para>Microsoft Docs page: <a href="https://docs.microsoft.com/en-gb/windows/win32/api/errhandlingapi/nf-errhandlingapi-fatalappexitw">FatalAppExitW function</a></para>
         /// </remarks>
         /// <exception cref="DllNotFoundException">The native library containg the function could not be found.</exception>
         /// <exception cref="EntryPointNotFoundException">Unable to find the entry point for the function in the native library.</exception>
+        /// <seealso href="https://docs.microsoft.com/windows/desktop/Debug/error-handling-functions">Error Handling Functions</seealso>
         /// <seealso cref="FatalExit"/>
-        public static void FatalAppExit(
-            int uAction,
-            string lpMessageText
-            ) => FatalAppExitW(uAction, lpMessageText);
+#if !NETSTANDARD1_6
+        [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
+        public static extern
+#else
+        public static
+#endif // !NETSTANDARD1_6
+        void FatalAppExit(
+            [In] int uAction,
+            [In] string lpMessageText
+            )
+#if !NETSTANDARD1_6
+            ;
+#else
+
+        {
+            switch (Marshal.SystemDefaultCharSize)
+            {
+                case 1:
+                    FatalAppExitA(uAction, lpMessageText);
+                    break;
+                case 2:
+                    FatalAppExitW(uAction, lpMessageText);
+                    break;
+                default: throw new PlatformNotSupportedException();
+            }
+        }
+#endif // !NETSTANDARD1_6
+
         /// <inheritdoc cref="FatalAppExit"/>
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, EntryPoint = nameof(FatalAppExitA))]
         public static extern void FatalAppExitA(
             [In] int uAction,
             [In, MarshalAs(UnmanagedType.LPStr)] string lpMessageText
             );
+
         /// <inheritdoc cref="FatalAppExit"/>
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, EntryPoint = nameof(FatalAppExitW))]
         public static extern void FatalAppExitW(
             [In] int uAction,
             [In, MarshalAs(UnmanagedType.LPWStr)] string lpMessageText
+            );
+
+        /// <inheritdoc cref="FatalAppExit"/>
+#if !NETSTANDARD1_6
+        [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
+        public static extern
+#else
+        public static
+#endif // !NETSTANDARD1_6
+        void FatalAppExit(
+            [In] int uAction,
+            [In] LPCTSTR lpMessageText
+            )
+#if !NETSTANDARD1_6
+            ;
+#else
+
+        {
+            switch (Marshal.SystemDefaultCharSize)
+            {
+                case 1:
+                    FatalAppExitA(uAction, Pointer.Create<LPCSTR>(lpMessageText.Pointer));
+                    break;
+                case 2:
+                    FatalAppExitW(uAction, Pointer.Create<LPCWSTR>(lpMessageText.Pointer));
+                    break;
+                default: throw new PlatformNotSupportedException();
+            }
+        }
+#endif // !NETSTANDARD1_6
+
+        /// <inheritdoc cref="FatalAppExit"/>
+        [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
+        public static extern void FatalAppExitA(
+            [In] int uAction,
+            [In] LPCSTR lpMessageText
+            );
+
+
+        /// <inheritdoc cref="FatalAppExit"/>
+        [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        public static extern void FatalAppExitW(
+            [In] int uAction,
+            [In] LPCWSTR lpMessageText
             );
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\errhandlingapi.h, line 250

--- a/src-native/THNETII.WinApi.Headers.ErrHandlingApi/ErrHandlingApiFunctions.cs
+++ b/src-native/THNETII.WinApi.Headers.ErrHandlingApi/ErrHandlingApiFunctions.cs
@@ -172,17 +172,17 @@ namespace THNETII.WinApi.Native.ErrHandlingApi
         /// <exception cref="EntryPointNotFoundException">Unable to find the entry point for the function in the native library.</exception>
         /// <seealso href="https://docs.microsoft.com/windows/desktop/Debug/error-handling-functions">Error Handling Functions</seealso>
         /// <seealso cref="FatalExit"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
         public static extern
 #else
         public static
-#endif // !NETSTANDARD1_6
+#endif // !(NETSTANDARD1_3 || NETSTANDARD1_6)
         void FatalAppExit(
             [In] int uAction,
             [In] string lpMessageText
             )
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
             ;
 #else
 
@@ -198,7 +198,7 @@ namespace THNETII.WinApi.Native.ErrHandlingApi
                 default: throw new PlatformNotSupportedException();
             }
         }
-#endif // !NETSTANDARD1_6
+#endif // !(NETSTANDARD1_3 || NETSTANDARD1_6)
 
         /// <inheritdoc cref="FatalAppExit"/>
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, EntryPoint = nameof(FatalAppExitA))]
@@ -215,17 +215,17 @@ namespace THNETII.WinApi.Native.ErrHandlingApi
             );
 
         /// <inheritdoc cref="FatalAppExit"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
         public static extern
 #else
         public static
-#endif // !NETSTANDARD1_6
+#endif // !(NETSTANDARD1_3 || NETSTANDARD1_6)
         void FatalAppExit(
             [In] int uAction,
             [In] LPCTSTR lpMessageText
             )
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
             ;
 #else
 
@@ -241,7 +241,7 @@ namespace THNETII.WinApi.Native.ErrHandlingApi
                 default: throw new PlatformNotSupportedException();
             }
         }
-#endif // !NETSTANDARD1_6
+#endif // !(NETSTANDARD1_3 || NETSTANDARD1_6)
 
         /// <inheritdoc cref="FatalAppExit"/>
         [DllImport(NativeLibraryNames.Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]

--- a/src-native/THNETII.WinApi.Headers.ErrHandlingApi/GlobalSuppressions.cs
+++ b/src-native/THNETII.WinApi.Headers.ErrHandlingApi/GlobalSuppressions.cs
@@ -1,12 +1,13 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage 
+// This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
 // a specific target and scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Interoperability", "CA1401: P/Invokes should not be visible")]
-[assembly: SuppressMessage("Usage", "PC003: Native API not available in UWP")]
 [assembly: SuppressMessage("Documentation", "CA1200: Avoid using cref tags with a prefix")]
-[assembly: SuppressMessage("Naming", "CA1707: Identifiers should not contain underscores")]
+[assembly: SuppressMessage("Documentation", "CS0419: Ambiguous reference in cref attribute")]
 [assembly: SuppressMessage("Globalization", "CA2101: Specify marshaling for P/Invoke string arguments")]
+[assembly: SuppressMessage("Interoperability", "CA1401: P/Invokes should not be visible")]
+[assembly: SuppressMessage("Naming", "CA1707: Identifiers should not contain underscores")]
+[assembly: SuppressMessage("Usage", "PC003: Native API not available in UWP")]

--- a/src-native/THNETII.WinApi.Headers.ErrHandlingApi/THNETII.WinApi.Headers.ErrHandlingApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.ErrHandlingApi/THNETII.WinApi.Headers.ErrHandlingApi.csproj
@@ -2,10 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS0419</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.ErrHandlingApi</RootNamespace>
   </PropertyGroup>
 

--- a/src-native/THNETII.WinApi.Headers.FileApi/FileApiFunctions.cs
+++ b/src-native/THNETII.WinApi.Headers.FileApi/FileApiFunctions.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.Win32.SafeHandles;
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 
+using THNETII.InteropServices.Memory;
 using THNETII.WinApi.Native.MinWinBase;
 using THNETII.WinApi.Native.MinWinDef;
 using THNETII.WinApi.Native.WinError;
@@ -59,49 +58,102 @@ namespace THNETII.WinApi.Native.FileApi
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\fileapi.h, line 56
         #region CreateDirectoryA function
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
+        /// <inheritdoc cref="CreateDirectory"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
         [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CreateDirectoryA(
-            [In] LPCSTR lpPathName,
+            [In] string lpPathName,
             [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
             );
-        /// <inheritdoc cref="CreateDirectoryA(LPCSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
-        public static bool CreateDirectoryA(LPCSTR lpPathName) =>
-            CreateDirectoryA(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectoryA(LPCSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CreateDirectoryA(
-            [In] LPCSTR lpPathName,
-            [In, Optional] IntPtr lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectoryA(LPCSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CreateDirectoryA(
-            [In, MarshalAs(UnmanagedType.LPStr)] string lpPathName,
-            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectoryA(LPCSTR, in SECURITY_ATTRIBUTES)"/>
+
+        /// <inheritdoc cref="CreateDirectoryA"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
         public static bool CreateDirectoryA(string lpPathName) =>
             CreateDirectoryA(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectoryA(LPCSTR, in SECURITY_ATTRIBUTES)"/>
+
+        /// <inheritdoc cref="CreateDirectoryA"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
         [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool CreateDirectoryA(
-            [In, MarshalAs(UnmanagedType.LPStr)] string lpPathName,
+            [In] string lpPathName,
+            [In, Optional] IntPtr lpSecurityAttributes
+            );
+
+        /// <inheritdoc cref="CreateDirectoryA"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CreateDirectoryA(
+            [In] LPCSTR lpPathName,
+            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
+            );
+
+        /// <inheritdoc cref="CreateDirectoryA"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
+        public static bool CreateDirectoryA(LPCSTR lpPathName) =>
+            CreateDirectoryA(lpPathName, IntPtr.Zero);
+
+        /// <inheritdoc cref="CreateDirectoryA"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryA) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Ansi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CreateDirectoryA(
+            [In] LPCSTR lpPathName,
             [In, Optional] IntPtr lpSecurityAttributes
             );
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\fileapi.h, line 64
         #region CreateDirectoryW function
+        /// <inheritdoc cref="CreateDirectory"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CreateDirectoryW(
+            [In] string lpPathName,
+            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
+            );
+
+        /// <inheritdoc cref="CreateDirectoryW"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        public static bool CreateDirectoryW(string lpPathName) =>
+            CreateDirectoryW(lpPathName, IntPtr.Zero);
+
+        /// <inheritdoc cref="CreateDirectoryW"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CreateDirectoryW(
+            [In] string lpPathName,
+            [In, Optional] IntPtr lpSecurityAttributes
+            );
+
+        /// <inheritdoc cref="CreateDirectoryW"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool CreateDirectoryW(
+            [In] LPCWSTR lpPathName,
+            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
+            );
+
+        /// <inheritdoc cref="CreateDirectoryW"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        public static bool CreateDirectoryW(LPCWSTR lpPathName) =>
+            CreateDirectoryW(lpPathName, IntPtr.Zero);
+
+        /// <inheritdoc cref="CreateDirectoryW"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CreateDirectoryW(
+            [In] LPCWSTR lpPathName,
+            [In, Optional] IntPtr lpSecurityAttributes
+            );
+        #endregion
+        // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\fileapi.h, line 72
+        #region CreateDirectory function
         /// <summary>
         /// Creates a new directory. If the underlying file system supports security on files and directories, the function applies a specified security descriptor to the new directory.
         /// <para>To specify a template directory, use the <see cref="CreateDirectoryEx"/> function.</para>
@@ -163,92 +215,120 @@ namespace THNETII.WinApi.Native.FileApi
         /// <seealso cref="RemoveDirectory"/>
         /// <seealso cref="SECURITY_ATTRIBUTES"/>
         /// <seealso cref="SECURITY_INFORMATION"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
+#if !NETSTANDARD1_3
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CreateDirectoryW(
-            [In] LPCWSTR lpPathName,
+        public static extern
+#else
+        public static
+#endif // NETSTANDARD1_3
+        bool CreateDirectory(
+            [In] string lpPathName,
             [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        public static bool CreateDirectoryW(LPCWSTR lpPathName) =>
-            CreateDirectoryW(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CreateDirectoryW(
-            [In] LPCWSTR lpPathName,
-            [In, Optional] IntPtr lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CreateDirectoryW(
-            [In, MarshalAs(UnmanagedType.LPWStr)] string lpPathName,
-            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        public static bool CreateDirectoryW(string lpPathName) =>
-            CreateDirectoryW(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectoryW) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CreateDirectoryW(
-            [In, MarshalAs(UnmanagedType.LPWStr)] string lpPathName,
-            [In, Optional] IntPtr lpSecurityAttributes
-            );
-        #endregion
-        // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\fileapi.h, line 72
-        #region CreateDirectory function
+            )
+#if !NETSTANDARD1_3
+            ;
+#else
+            => Marshal.SystemDefaultCharSize switch
+            {
+                1 => CreateDirectoryA(lpPathName, lpSecurityAttributes),
+                2 => CreateDirectoryW(lpPathName, lpSecurityAttributes),
+                _ => throw new PlatformNotSupportedException(),
+            };
+#endif // NETSTANDARD1_3
+
         /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi)]
+        public static bool CreateDirectory(
+            string lpPathName
+            ) => CreateDirectory(lpPathName, IntPtr.Zero);
+
+        /// <inheritdoc cref="CreateDirectoryW(LPCWSTR, in SECURITY_ATTRIBUTES)"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
+#if !NETSTANDARD1_3
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CreateDirectory(
+        private static extern
+#else
+        private static
+#endif // NETSTANDARD1_3
+        bool CreateDirectory(
+            [In] string lpPathName,
+            [In, Optional] IntPtr lpSecurityAttributes
+            )
+#if !NETSTANDARD1_3
+            ;
+#else
+            => Marshal.SystemDefaultCharSize switch
+            {
+                1 => CreateDirectoryA(lpPathName, lpSecurityAttributes),
+                2 => CreateDirectoryW(lpPathName, lpSecurityAttributes),
+                _ => throw new PlatformNotSupportedException(),
+            };
+#endif // NETSTANDARD1_3
+
+        /// <inheritdoc cref="CreateDirectory"/>
+        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
+#if !NETSTANDARD1_3
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern
+#else
+        public static
+#endif // NETSTANDARD1_3
+        bool CreateDirectory(
             [In] LPCTSTR lpPathName,
             [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectory(LPCTSTR, in SECURITY_ATTRIBUTES)"/>
+            )
+#if !NETSTANDARD1_3
+            ;
+#else
+            => Marshal.SystemDefaultCharSize switch
+            {
+                1 => CreateDirectoryA(
+                    Pointer.Create<LPCSTR>(lpPathName.Pointer),
+                    lpSecurityAttributes),
+                2 => CreateDirectoryW(
+                    Pointer.Create<LPCWSTR>(lpPathName.Pointer),
+                    lpSecurityAttributes),
+                _ => throw new PlatformNotSupportedException(),
+            };
+#endif // NETSTANDARD1_3
+
+        /// <inheritdoc cref="CreateDirectory"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
         public static bool CreateDirectory(
             [In] LPCTSTR lpPathName
-            ) =>
-            CreateDirectory(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectory(LPCTSTR, in SECURITY_ATTRIBUTES)"/>
+            ) => CreateDirectory(lpPathName, IntPtr.Zero);
+
+        /// <inheritdoc cref="CreateDirectory"/>
         [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi)]
+#if !NETSTANDARD1_3
+        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CreateDirectory(
+        private static extern
+#else
+        private static
+#endif // NETSTANDARD1_3
+        bool CreateDirectory(
             [In] LPCTSTR lpPathName,
             [In, Optional] IntPtr lpSecurityAttributes
-            );
+            )
 #if !NETSTANDARD1_3
-        /// <inheritdoc cref="CreateDirectory(LPCTSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CreateDirectory(
-            [In, MarshalAs(UnmanagedType.LPTStr)] string lpPathName,
-            [In, Optional] in SECURITY_ATTRIBUTES lpSecurityAttributes
-            );
-        /// <inheritdoc cref="CreateDirectory(LPCTSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
-        public static bool CreateDirectory(string lpPathName) =>
-            CreateDirectory(lpPathName, IntPtr.Zero);
-        /// <inheritdoc cref="CreateDirectory(LPCTSTR, in SECURITY_ATTRIBUTES)"/>
-        [Obsolete(".NET Applications should not call " + nameof(CreateDirectory) + ". Instead the types in the System.IO namespace should be used.")]
-        [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CreateDirectory(
-            [In, MarshalAs(UnmanagedType.LPTStr)] string lpPathName,
-            [In, Optional] IntPtr lpSecurityAttributes
-            );
-#endif // !NETSTANDARD1_3
+            ;
+#else
+            => Marshal.SystemDefaultCharSize switch
+            {
+                1 => CreateDirectoryA(
+                    Pointer.Create<LPCSTR>(lpPathName.Pointer),
+                    lpSecurityAttributes),
+                2 => CreateDirectoryW(
+                    Pointer.Create<LPCWSTR>(lpPathName.Pointer),
+                    lpSecurityAttributes),
+                _ => throw new PlatformNotSupportedException(),
+            };
+#endif // NETSTANDARD1_3
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\fileapi.h, line 116
         #region DefineDosDeviceW function

--- a/src-native/THNETII.WinApi.Headers.FileApi/GlobalSuppressions.cs
+++ b/src-native/THNETII.WinApi.Headers.FileApi/GlobalSuppressions.cs
@@ -1,11 +1,12 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Naming", "CA1707: Identifiers should not contain underscores")]
-[assembly: SuppressMessage("Interoperability", "CA1401: P/Invokes should not be visible")]
+[assembly: SuppressMessage("Documentation", "CS0419: Ambiguous reference in cref attribute")]
 [assembly: SuppressMessage("Globalization", "CA2101: Specify marshaling for P/Invoke string arguments", Justification = "Erroneously reported as not specified")]
+[assembly: SuppressMessage("Interoperability", "CA1401: P/Invokes should not be visible")]
+[assembly: SuppressMessage("Naming", "CA1707: Identifiers should not contain underscores")]
 [assembly: SuppressMessage("Usage", "PC003: Native API not available in UWP")]

--- a/src-native/THNETII.WinApi.Headers.FileApi/THNETII.WinApi.Headers.FileApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.FileApi/THNETII.WinApi.Headers.FileApi.csproj
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS0419</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.FileApi</RootNamespace>
   </PropertyGroup>
 

--- a/src-native/THNETII.WinApi.Headers.MinWinDef/MinWinDefMacros.cs
+++ b/src-native/THNETII.WinApi.Headers.MinWinDef/MinWinDefMacros.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using THNETII.InteropServices.Bitwise;
 
 namespace THNETII.WinApi.Native.MinWinDef

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/COMPUTER_NAME_FORMAT.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/COMPUTER_NAME_FORMAT.cs
@@ -1,5 +1,7 @@
-﻿namespace THNETII.WinApi.Native.SysInfoApi
+namespace THNETII.WinApi.Native.SysInfoApi
 {
+    using static SysInfoApiFunctions;
+
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line 296
     /// <summary>
     /// Specifies a type of computer name.

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/GlobalSuppressions.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -13,3 +13,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Usage", "PC003: Native API not available in UWP")]
 [assembly: SuppressMessage("Globalization", "CA2101: Specify marshaling for P/Invoke string arguments")]
 [assembly: SuppressMessage("Documentation", "CA1200: Avoid using cref tags with a prefix")]
+[assembly: SuppressMessage("Documentation", "CS0419: Ambiguous cref reference")]

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/MEMORYSTATUSEX.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/MEMORYSTATUSEX.cs
@@ -1,10 +1,12 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 using THNETII.InteropServices.Memory;
 
 namespace THNETII.WinApi.Native.SysInfoApi
 {
+    using static SysInfoApiFunctions;
+
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line 72
     /// <summary>
     /// Contains information about the current state of both physical and virtual memory, including extended memory. The <see cref="GlobalMemoryStatusEx"/> function stores information in this structure.
@@ -48,7 +50,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
         /// </summary>
         public ulong ullTotalPageFile;
         /// <summary>
-        /// The maximum amount of memory the current process can commit, in bytes. This value is equal to or smaller than the system-wide available commit value. To calculate the system-wide available commit value, call <see cref="GetPerformanceInfo"/> and subtract the value of <see cref="CommitTotal"/> from the value of <see cref="CommitLimit"/>.
+        /// The maximum amount of memory the current process can commit, in bytes. This value is equal to or smaller than the system-wide available commit value. To calculate the system-wide available commit value, call <see cref="GetPerformanceInfo"/> and subtract the value of <see cref="PERFORMANCE_INFORMATION.CommitTotal"/> from the value of <see cref="PERFORMANCE_INFORMATION.CommitLimit"/>.
         /// </summary>
         public ulong ullAvailPageFile;
         /// <summary>

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/SYSTEM_INFO.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/SYSTEM_INFO.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 
@@ -6,7 +6,9 @@ using THNETII.WinApi.Native.WinNT;
 
 namespace THNETII.WinApi.Native.SysInfoApi
 {
+    using static LOGICAL_PROCESSOR_RELATIONSHIP;
     using static PROCESSOR_ARCHITECTURE;
+    using static SysInfoApiFunctions;
 
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line 47
     /// <summary>

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/SysInfoApiFunctions.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/SysInfoApiFunctions.cs
@@ -1,8 +1,11 @@
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
 using THNETII.InteropServices.Memory;
+using THNETII.WinApi.Native.ErrHandlingApi;
 using THNETII.WinApi.Native.MinWinBase;
 using THNETII.WinApi.Native.WinError;
 using THNETII.WinApi.Native.WinNT;
@@ -14,6 +17,7 @@ using EntryPointNotFoundException = System.Exception;
 namespace THNETII.WinApi.Native.SysInfoApi
 {
     using static COMPUTER_NAME_FORMAT;
+    using static ErrHandlingApiFunctions;
     using static LOGICAL_PROCESSOR_RELATIONSHIP;
     using static NativeLibraryNames;
     using static WinErrorConstants;

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/THNETII.WinApi.Headers.SysInfoApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/THNETII.WinApi.Headers.SysInfoApi.csproj
@@ -6,7 +6,7 @@
     <LangVersion>7.3</LangVersion>
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS0419;CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.SysInfoApi</RootNamespace>
   </PropertyGroup>
 
@@ -26,6 +26,12 @@
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\THNETII.WinApi.Constants.WinNT\THNETII.WinApi.Constants.WinNT.csproj">
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\THNETII.WinApi.Headers.ErrHandlingApi\THNETII.WinApi.Headers.ErrHandlingApi.csproj">
+      <PrivateAssets>All</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\THNETII.WinApi.Headers.WinUser\THNETII.WinApi.Headers.WinUser.csproj">
       <PrivateAssets>All</PrivateAssets>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
- [x] `errhandlingapi.h`
- [x] `fileapi.h`