### PR TITLE
.NET Standard 1.3 Compatability

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,12 +27,12 @@ jobs:
     common:
       allProjects: |
         [Ss]rc/*/*.csproj
-        [Ss]rc-[Nn]native/*/*.csproj
+        [Ss]rc-[Nn]ative/*/*.csproj
         [Ss]rc-[Ss]hared/*/*.csproj
         [Tt]est/*/*.csproj
       srcProjects: |
         [Ss]rc/*/*.csproj
-        [Ss]rc-[Nn]native/*/*.csproj
+        [Ss]rc-[Nn]ative/*/*.csproj
         [Ss]rc-[Ss]hared/*/*.csproj
       testProjects: |
         [Tt]est/*/*.csproj

--- a/src-native/THNETII.WinApi.Extensions.MinWinBase/THNETII.WinApi.Extensions.MinWinBase.csproj
+++ b/src-native/THNETII.WinApi.Extensions.MinWinBase/THNETII.WinApi.Extensions.MinWinBase.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.MinWinBase</RootNamespace>

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_ENTRY.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_ENTRY.cs
@@ -73,7 +73,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// </remarks>
     /// <seealso cref="ACTRL_ACCESS_ENTRY_LIST"/>
     /// <seealso cref="TRUSTEE"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_ENTRY_LIST.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_ENTRY_LIST.cs
@@ -59,7 +59,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// <para>Microsoft Docs page: <a href="https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ns-accctrl-actrl_access_entry_listw">ACTRL_ACCESS_ENTRY_LISTW structure</a></para>
     /// </remarks>
     /// <seealso cref="ACTRL_PROPERTY_ENTRY"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_INFO.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ACCESS_INFO.cs
@@ -27,7 +27,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     }
 
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\AccCtrl.h, line 680
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ALIST.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_ALIST.cs
@@ -50,7 +50,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     }
 
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\AccCtrl.h, line 476
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_CONTROL_INFO.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_CONTROL_INFO.cs
@@ -25,7 +25,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     }
 
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\AccCtrl.h, line 698
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_PROPERTY_ENTRY.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/ACTRL_PROPERTY_ENTRY.cs
@@ -40,7 +40,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// <para>Microsoft Docs page: <a href="https://docs.microsoft.com/en-us/windows/win32/api/accctrl/ns-accctrl-actrl_property_entryw">ACTRL_PROPERTY_ENTRYW structure</a></para>
     /// </remarks>
     /// <seealso cref="ACTRL_ACCESS_ENTRY_LIST"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/EXPLICIT_ACCESS.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/EXPLICIT_ACCESS.cs
@@ -75,7 +75,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// <seealso cref="LookupSecurityDescriptorParts"/>
     /// <seealso cref="SetEntriesInAcl"/>
     /// <seealso cref="TRUSTEE"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/INHERITED_FROM.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/INHERITED_FROM.cs
@@ -49,7 +49,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// </remarks>
     /// <seealso cref="FreeInheritedFromArray"/>
     /// <seealso cref="GetInheritanceSource"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/OBJECTS_AND_NAME.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/OBJECTS_AND_NAME.cs
@@ -59,7 +59,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// <seealso cref="SE_OBJECT_TYPE"/>
     /// <seealso cref="SetEntriesInAcl"/>
     /// <seealso cref="TRUSTEE"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)] 

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/THNETII.WinApi.Headers.AccCtrl.csproj
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/THNETII.WinApi.Headers.AccCtrl.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>THNETII.WinApi.Native.AccCtrl</RootNamespace>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/THNETII.WinApi.Headers.AccCtrl.csproj
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/THNETII.WinApi.Headers.AccCtrl.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>THNETII.WinApi.Native.AccCtrl</RootNamespace>
   </PropertyGroup>

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/TRUSTEE.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/TRUSTEE.cs
@@ -170,7 +170,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     /// <seealso cref="SetEntriesInAcl"/>
     /// <seealso cref="TRUSTEE_FORM"/>
     /// <seealso cref="TRUSTEE_TYPE"/>
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.AccCtrl/TRUSTEE_ACCESS.cs
+++ b/src-native/THNETII.WinApi.Headers.AccCtrl/TRUSTEE_ACCESS.cs
@@ -37,7 +37,7 @@ namespace THNETII.WinApi.Native.AccCtrl
     }
 
     // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\AccCtrl.h, line 518
-#if !NETSTANDARD1_6
+#if !(NETSTANDARD1_3 || NETSTANDARD1_6)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
 #else
     [StructLayout(LayoutKind.Sequential)]

--- a/src-native/THNETII.WinApi.Headers.ErrHandlingApi/THNETII.WinApi.Headers.ErrHandlingApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.ErrHandlingApi/THNETII.WinApi.Headers.ErrHandlingApi.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.ErrHandlingApi</RootNamespace>

--- a/src-native/THNETII.WinApi.Headers.HandleApi/THNETII.WinApi.Headers.HandleApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.HandleApi/THNETII.WinApi.Headers.HandleApi.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.HandleApi</RootNamespace>

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/SysInfoApiFunctions.cs
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/SysInfoApiFunctions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32.SafeHandles;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -470,7 +470,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [In] int uSize
             );
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="GetSystemDirectory(LPTSTR, int)"/>
         public static int GetSystemDirectory(
             StringBuilder lpBuffer
@@ -482,7 +482,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [Out] StringBuilder lpBuffer,
             [In] int uSize
             ); 
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 240
         #region GetWindowsDirectoryA function
@@ -565,7 +565,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [In] int uSize
             );
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="GetWindowsDirectory(LPTSTR, int)"/>
         public static int GetWindowsDirectory(
             StringBuilder lpBuffer
@@ -577,7 +577,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [Out] StringBuilder lpBuffer,
             [In] int uSize
             );
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 266
         #region GetSystemWindowsDirectoryA function
@@ -657,7 +657,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [In] int uSize
             );
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="GetSystemWindowsDirectory(LPTSTR, int)"/>
         public static int GetSystemWindowsDirectory(
             StringBuilder lpBuffer
@@ -669,7 +669,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [Out] StringBuilder lpBuffer,
             [In] int uSize
             );
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 314
         #region GetComputerNameExA function
@@ -804,7 +804,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             ref int nSize
             );
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="GetComputerNameEx(COMPUTER_NAME_FORMAT, LPTSTR, ref int)"/>
         public static bool GetComputerNameEx(
             COMPUTER_NAME_FORMAT NameType,
@@ -824,7 +824,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [Out] StringBuilder lpBuffer,
             ref int nSize
             );
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 346
         #region SetComputerNameExW function
@@ -892,7 +892,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             LPCTSTR lpBuffer
             );
 
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="SetComputerNameEx(COMPUTER_NAME_FORMAT, LPCTSTR)"/>
         [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, SetLastError = true, CharSet = CharSet.Auto)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -900,7 +900,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [In] COMPUTER_NAME_FORMAT NameType,
             [In] string lpBuffer
             );
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 359
         #region SetSystemTime function
@@ -1584,7 +1584,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 563
         #region SetComputerNameEx2 function
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <exception cref="DllNotFoundException">The native library containg the function could not be found.</exception>
         /// <exception cref="EntryPointNotFoundException">Unable to find the entry point for the function in the native library.</exception>
         [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi,
@@ -1595,7 +1595,7 @@ namespace THNETII.WinApi.Native.SysInfoApi
             [In, MarshalAs(UnmanagedType.I4)] SCEX2_FLAGS Flags,
             [In] string lpBuffer
             ); 
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
 
         /// <exception cref="DllNotFoundException">The native library containg the function could not be found.</exception>
         /// <exception cref="EntryPointNotFoundException">Unable to find the entry point for the function in the native library.</exception>
@@ -1864,14 +1864,14 @@ namespace THNETII.WinApi.Native.SysInfoApi
         #endregion
         // C:\Program Files (x86)\Windows Kits\10\Include\10.0.17134.0\um\sysinfoapi.h, line: 664
         #region SetComputerName function
-#if !NETSTANDARD1_6
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
         /// <inheritdoc cref="SetComputerName(LPCTSTR)"/>
         [DllImport(Kernel32, CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Auto, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SetComputerName(
             [In] string lpComputerName
             ); 
-#endif // !NETSTANDARD1_6
+#endif // !NETSTANDARD1_3 && !NETSTANDARD1_6
 
         /// <summary>
         /// <para>Sets a new NetBIOS name for the local computer. The name is stored in the registry and the name change takes effect the next time the user restarts the computer.</para>

--- a/src-native/THNETII.WinApi.Headers.SysInfoApi/THNETII.WinApi.Headers.SysInfoApi.csproj
+++ b/src-native/THNETII.WinApi.Headers.SysInfoApi/THNETII.WinApi.Headers.SysInfoApi.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.SysInfoApi</RootNamespace>

--- a/src-native/THNETII.WinApi.Headers.WinBase/THNETII.WinApi.Headers.WinBase.csproj
+++ b/src-native/THNETII.WinApi.Headers.WinBase/THNETII.WinApi.Headers.WinBase.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <RootNamespace>THNETII.WinApi.Native.WinBase</RootNamespace>

--- a/src-native/THNETII.WinApi.Headers.WinNT/THNETII.WinApi.Headers.WinNT.csproj
+++ b/src-native/THNETII.WinApi.Headers.WinNT/THNETII.WinApi.Headers.WinNT.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src-native/THNETII.WinApi.Headers.WinNT/WinNTRuntimeConstants.cs
+++ b/src-native/THNETII.WinApi.Headers.WinNT/WinNTRuntimeConstants.cs
@@ -1,10 +1,14 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
 using THNETII.InteropServices.Memory;
+
+#if NETSTANDARD1_3
+using NotifyFilters = System.Int32;
+#endif
 
 namespace THNETII.WinApi.Native.WinNT
 {


### PR DESCRIPTION
Enforce at least .NET Standard 1.3 compatability.

All dependencies that cannot be met for .NET Standard 1.3 will be hidden by `#ifdef` and conditional project/package references